### PR TITLE
🚑 Quick temporary fix to positive news feed

### DIFF
--- a/app/Http/Controllers/Api/PositiveNewsController.php
+++ b/app/Http/Controllers/Api/PositiveNewsController.php
@@ -45,6 +45,8 @@ class PositiveNewsController extends Controller
             return $this->goodNewsNetworkResults;
         });
 
-        return response()->json(['data' => $jsonData]);
+        return response()->json([
+            'data' => $jsonData,
+        ], 200, [], JSON_UNESCAPED_UNICODE | JSON_INVALID_UTF8_SUBSTITUTE);
     }
 }


### PR DESCRIPTION
There was a 500 error returning from the positive news scraper due to malformed UTF-8 character(s)

TEMPORARY FIX:

- I returned data to allow for these characters replacing them as appropriate